### PR TITLE
Netcore project support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# EditorConfig helps developers define and
+# maintain consistent coding styles between
+# different editors and IDEs
+
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+# Make selection with keyboard easier in all files
+insert_final_newline = true
+
+[*.proj]
+indent_size = 2
+
+[*.csproj]
+indent_size = 2
+
+[*.vcxproj]
+indent_size = 2
+
+[*.xproj]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.config]
+indent_size = 2
+
+[*.nuspec]
+indent_size = 2
+
+[*.xml]
+indent_size = 2
+
+[*.cs]
+csharp_new_line_before_open_brace = all

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+VS Project Loader Extension 3.7 - August 6, 2017
+
+  Added support for new file format for .NET Core csproj files. Added .editorconfig for
+  consistency with main NUnit project.
+
+  Issues Resolved
+
+   * 11 Invalid Project Format Exception if Project is new project file format
+
 VS Project Loader Extension 3.6 - August 1, 2017
 
   Fixes several packaging errors and adds a new chocolatey package. Runners and engines

--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -285,13 +285,13 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     if (!_configs.ContainsKey("Debug"))
                     {
                         string configName = "Debug";
-                        string outputPath = $"bin/{configName}/{targetFramework}";
+                        string outputPath = $@"bin\{configName}\{targetFramework}";
                         _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
                     }
                     if (!_configs.ContainsKey("Release"))
                     {
                         string configName = "Release";
-                        string outputPath = $"bin/{configName}/{targetFramework}";
+                        string outputPath = $@"bin\{configName}\{targetFramework}";
                         _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
                     }
                 }

--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -247,7 +247,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                 string targetFramework = _doc.SelectSingleNode("Project/PropertyGroup/TargetFramework").InnerText;
 
                 XmlNode assemblyNameNode = _doc.SelectSingleNode("Project/PropertyGroup/AssemblyName");
-                // Even console apps are dll's
+                // Even console apps are dll's even if <OutputType> has value 'EXE'
                 string assemblyName = assemblyNameNode == null ? $"{Name}.dll" : $"{assemblyNameNode.InnerText}.dll";
 
                 XmlNodeList nodes = _doc.SelectNodes("/Project/PropertyGroup");
@@ -276,10 +276,10 @@ namespace NUnit.Engine.Services.ProjectLoaders
                         _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
                 }
 
-                // By convention there is a Debug and Release configuration unless others are explicitly 
+                // By convention there is a Debug and a Release configuration unless others are explicitly 
                 // mentioned in the project file. If we have less than 2 then at least one of those is missing.
                 // We cannot tell however if the existing configuration is meant to replace Debug or Release.
-                // Therefore we just add both if both are missing. The one that has been replaced will not be called.
+                // Therefore we just add what is missing. The one that has been replaced will not be used.
                 if (_configs.Count < 2)
                 {
                     if (!_configs.ContainsKey("Debug"))

--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -187,17 +187,23 @@ namespace NUnit.Engine.Services.ProjectLoaders
                 ThrowInvalidFileType( ProjectPath );
 
             StreamReader rdr = new StreamReader(ProjectPath, System.Text.Encoding.UTF8);
-            
+
             try
             {
                 _doc = new XmlDocument();
-                _doc.Load( rdr );
+                _doc.Load(rdr);
 
-                string extension = Path.GetExtension( ProjectPath );
+                string extension = Path.GetExtension(ProjectPath);
 
-                switch ( extension )
+                switch (extension)
                 {
                     case ".csproj":
+                        // We try legacy project first, then new format for .NET Core projects
+                        if (!TryLoadLegacyProject())
+                            if (!TryLoadDotNetCoreProject())
+                                LoadMSBuildProject();
+                        break;
+
                     case ".vbproj":
                     case ".vjsproj":
                     case ".fsproj":
@@ -226,6 +232,74 @@ namespace NUnit.Engine.Services.ProjectLoaders
             {
                 rdr.Close();
             }
+        }
+
+        /// <summary>
+        /// Load a project in the new project format for .NET Core 1.0/1.1. Note that this method
+        /// is only called for file extensions .csproj.
+        /// </summary>
+        /// <returns>True if the project was successfully loaded, false otherwise.</returns>
+        private bool TryLoadDotNetCoreProject() {
+            XmlNode root = _doc.SelectSingleNode("Project");
+
+            if (root != null && SafeAttributeValue(root, "Sdk") != null) 
+            {
+                string targetFramework = _doc.SelectSingleNode("Project/PropertyGroup/TargetFramework").InnerText;
+
+                XmlNode assemblyNameNode = _doc.SelectSingleNode("Project/PropertyGroup/AssemblyName");
+                // Even console apps are dll's
+                string assemblyName = assemblyNameNode == null ? $"{Name}.dll" : $"{assemblyNameNode.InnerText}.dll";
+
+                XmlNodeList nodes = _doc.SelectNodes("/Project/PropertyGroup");
+
+                string commonOutputPath = null;
+
+                foreach (XmlElement configNode in nodes)
+                {
+                    string configName = GetConfigNameFromCondition(configNode);
+
+                    XmlElement outputPathElement = (XmlElement)configNode.SelectSingleNode("OutputPath");
+                    string outputPath = null;
+                    if (outputPathElement != null)
+                        outputPath = outputPathElement.InnerText;
+
+                    if (configName == null)
+                    {
+                        commonOutputPath = outputPath;
+                        continue;
+                    }
+
+                    if (outputPath == null)
+                        outputPath = commonOutputPath;
+
+                    if (outputPath != null)
+                        _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
+                }
+
+                // By convention there is a Debug and Release configuration unless others are explicitly 
+                // mentioned in the project file. If we have less than 2 then at least one of those is missing.
+                // We cannot tell however if the existing configuration is meant to replace Debug or Release.
+                // Therefore we just add both if both are missing. The one that has been replaced will not be called.
+                if (_configs.Count < 2)
+                {
+                    if (!_configs.ContainsKey("Debug"))
+                    {
+                        string configName = "Debug";
+                        string outputPath = $"bin/{configName}/{targetFramework}";
+                        _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
+                    }
+                    if (!_configs.ContainsKey("Release"))
+                    {
+                        string configName = "Release";
+                        string outputPath = $"bin/{configName}/{targetFramework}";
+                        _configs.Add(configName, new ProjectConfig(this, configName, outputPath, assemblyName));
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -159,6 +159,23 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [TestCase("netcoreapp1.1-minimal.csproj", "netcoreapp1.1-minimal")]
+        [TestCase("netcoreapp1.1-with-assembly-name.csproj", "the-assembly-name")]
+        public void PicksUpCorrectAssemplyName(string resouresName, string expectedAssemblyName)
+        {
+            using (TestResource file = new TestResource(resouresName))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+
+                foreach(var config in project.ConfigNames)
+                {
+                    TestPackage package = project.GetTestPackage(config);
+
+                    Assert.That(Path.GetFileNameWithoutExtension(package.SubPackages[0].FullName) == expectedAssemblyName);
+                }
+            }
+        }
+
         [Test]
         public void FromVSSolution2003()
         {

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Tests.resources;
 using NUnit.Framework;
@@ -119,6 +120,7 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
         [TestCase("legacy-cpp-sample.vcproj", new string[] { "Debug|Win32", "Release|Win32" }, "cpp-sample")]
         [TestCase("legacy-cpp-library-with-macros.vcproj", new string[] { "Debug|Win32", "Release|Win32" }, "legacy-cpp-library-with-macros")]
         [TestCase("legacy-cpp-makefile-project.vcproj", new string[] { "Debug|Win32", "Release|Win32" }, "MakeFileProject")]
+        [TestCase("netcoreapp1.1-minimal.csproj", new string[] { "Debug", "Release" }, "netcoreapp1.1-minimal")]
         public void CanLoadVsProject(string resourceName, string[] configs, string assemblyName)
         {
             Assert.That(_loader.CanLoadFrom(resourceName));
@@ -139,6 +141,18 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                     Assert.That(package.Settings.ContainsKey("BasePath"));
                     Assert.That(Path.GetDirectoryName(package.SubPackages[0].FullName), Is.SamePath((string)package.Settings["BasePath"]));
                 }
+            }
+        }
+
+        [TestCase("netcoreapp1.1-with-output-path.csproj", "Release", @"bin\Release\special")]
+        public void PicksUpCorrectOutputPath(string resourceName, string configuration, string expectedOutputPath)
+        {
+            using (TestResource file = new TestResource(resourceName))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+
+                var package = project.GetTestPackage(configuration);
+                Assert.That(package.Settings["BasePath"].ToString().EndsWith(expectedOutputPath));
             }
         }
 

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -144,6 +144,9 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [TestCase("netcoreapp1.1-minimal.csproj", "Debug", @"bin\Debug\netcoreapp1.1")]
+        [TestCase("netcoreapp1.1-minimal.csproj", "Release", @"bin\Release\netcoreapp1.1")]
+        [TestCase("netcoreapp1.1-with-output-path.csproj", "Debug", @"bin\Debug\netcoreapp1.1")]
         [TestCase("netcoreapp1.1-with-output-path.csproj", "Release", @"bin\Release\special")]
         public void PicksUpCorrectOutputPath(string resourceName, string configuration, string expectedOutputPath)
         {

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -144,10 +144,10 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
-        [TestCase("netcoreapp1.1-minimal.csproj", "Debug", @"bin\Debug\netcoreapp1.1")]
-        [TestCase("netcoreapp1.1-minimal.csproj", "Release", @"bin\Release\netcoreapp1.1")]
-        [TestCase("netcoreapp1.1-with-output-path.csproj", "Debug", @"bin\Debug\netcoreapp1.1")]
-        [TestCase("netcoreapp1.1-with-output-path.csproj", "Release", @"bin\Release\special")]
+        [TestCase("netcoreapp1.1-minimal.csproj", "Debug", @"bin/Debug/netcoreapp1.1")]
+        [TestCase("netcoreapp1.1-minimal.csproj", "Release", @"bin/Release/netcoreapp1.1")]
+        [TestCase("netcoreapp1.1-with-output-path.csproj", "Debug", @"bin/Debug/netcoreapp1.1")]
+        [TestCase("netcoreapp1.1-with-output-path.csproj", "Release", @"bin/Release/special")]
         public void PicksUpCorrectOutputPath(string resourceName, string configuration, string expectedOutputPath)
         {
             using (TestResource file = new TestResource(resourceName))
@@ -155,7 +155,9 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 IProject project = _loader.LoadFrom(file.Path);
 
                 var package = project.GetTestPackage(configuration);
-                Assert.That(package.Settings["BasePath"].ToString().EndsWith(expectedOutputPath));
+                // adjust for difference between Linux/Win:
+                var basePath = package.Settings["BasePath"].ToString().Replace('\\', '/');
+                Assert.That(basePath.EndsWith(expectedOutputPath));
             }
         }
 

--- a/src/tests/resources/netcoreapp1.1-minimal.csproj
+++ b/src/tests/resources/netcoreapp1.1-minimal.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/resources/netcoreapp1.1-with-assembly-name.csproj
+++ b/src/tests/resources/netcoreapp1.1-with-assembly-name.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <AssemblyName>the-assembly-name</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/resources/netcoreapp1.1-with-output-path.csproj
+++ b/src/tests/resources/netcoreapp1.1-with-output-path.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\special</OutputPath>
+  </PropertyGroup>
+
+</Project>

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -103,6 +103,9 @@
   <ItemGroup>
     <EmbeddedResource Include="resources\netcoreapp1.1-with-output-path.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\netcoreapp1.1-with-assembly-name.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -97,6 +97,12 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\netcoreapp1.1-minimal.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\netcoreapp1.1-with-output-path.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vs-project-loader.sln
+++ b/vs-project-loader.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vs-project-loader", "src\extension\vs-project-loader.csproj", "{96181317-7B6F-49F0-B283-6E804D41C8AF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6217E5FA-D329-4278-9307-7FCF8F48E9F1}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake


### PR DESCRIPTION
This PR is a suggested fix for issue #11 

A description of the changes:

I've added tests and implementation to account for the variations that I am aware of when settings are changed in the new csproj file format for .NET Core projects.

I've tried to keep changes to existing code to a minimum. Majority of new functionality is in a new method in VSProject.cs.

I've also added tests. One is another TestCase for an existing method. I also added two more tests with several TestCases each.

I also tested building and using the nuget package locally. I'm sure that if you decided to accept this PR that you want to test this in your environment as well.

I add file .editorconfig which is present in the main NUnit project and which I felt was missing here for consistency. VS 2017 has support for it. In it I added a rule for *.cs files to have a new line before left hand braces and a rule for all files to have a newline at the very end. The latter makes selection of text in files with the keyboard much easier. Also, since I use a different code style in other projects, adding .editorconfig made it much easier to follow the existing code style.

I updated CHANGE.txt to include a short description to reflect the changes if this fix. If you decide to merge this pull request please review the changes in this file as well in particular the release number.

Let me know if there are any oversights on my end. Constructive feedback is definitely appreciated. Thank you!