### PR TITLE
Fix for issue 16

### DIFF
--- a/src/extension/VSSolution.cs
+++ b/src/extension/VSSolution.cs
@@ -126,8 +126,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                         {
                             var vsProject = new VSProject(Path.Combine(solutionDirectory, vsProjectPath));
 
-                            if (CheckProjectReferencesNunit(vsProject))
-                                _projectLookup[vsProjectGuid] = vsProject;
+                            _projectLookup[vsProjectGuid] = vsProject;
                         }
                     }
                     else if (line.IndexOf(BUILD_MARKER) >= 0)
@@ -177,35 +176,6 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     line = reader.ReadLine();
                 }
             }
-        }
-
-        private bool CheckProjectReferencesNunit(VSProject vsProject)
-        {
-            if (vsProject.MsBuildDocument == null)
-                return true;
-
-            var doc = vsProject.MsBuildDocument;
-            var namespaceManager = new XmlNamespaceManager(doc.NameTable);
-            namespaceManager.AddNamespace("msbuild", "http://schemas.microsoft.com/developer/msbuild/2003");
-
-            var hasNunitReference =
-                doc.SelectNodes("/msbuild:Project/msbuild:ItemGroup/msbuild:Reference[@Include]", namespaceManager);
-
-            if (hasNunitReference == null)
-                return false;
-
-            foreach (XmlNode reference in hasNunitReference)
-            {
-                if (reference.Attributes != null)
-                {
-                    var value = reference.Attributes["Include"].Value.ToUpper();
-
-                    if (value.StartsWith("NUNIT.FRAMEWORK"))
-                        return true;
-                }
-            }
-
-            return false;
         }
 
         #endregion

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -263,7 +263,20 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             {
                 IProject project = _loader.LoadFrom(file.Path);
                 Assert.AreEqual(2, project.ConfigNames.Count);
-                Assert.AreEqual(1, project.GetTestPackage("Release").SubPackages.Count, "Release should have 2 assemblies");
+                Assert.AreEqual(2, project.GetTestPackage("Release").SubPackages.Count, "Release should have 2 assemblies");
+                Assert.AreEqual(2, project.GetTestPackage("Debug").SubPackages.Count, "Debug should have 2 assemblies");
+            }
+        }
+
+        [Test]
+        public void FromSolutinoWithProjectUsingPackageReference()
+        {
+            using (new TestResource("project-with-package-reference.csproj", NormalizePath(@"project-with-package-reference\project-with-package-reference.csproj")))
+            using(TestResource file = new TestResource("solution-with-package-reference.sln"))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+                Assert.AreEqual(2, project.ConfigNames.Count);
+                Assert.AreEqual(1, project.GetTestPackage("Release").SubPackages.Count, "Release should have 1 assemblies");
                 Assert.AreEqual(1, project.GetTestPackage("Debug").SubPackages.Count, "Debug should have 1 assembly");
             }
         }

--- a/src/tests/resources/project-with-package-reference.csproj
+++ b/src/tests/resources/project-with-package-reference.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B2D919F2-171A-4D4A-9190-21ADC79BADA8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>project_with_package_reference</RootNamespace>
+    <AssemblyName>project-with-package-reference</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit">
+      <Version>3.7.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/tests/resources/solution-with-package-reference.sln
+++ b/src/tests/resources/solution-with-package-reference.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.8
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "project-with-package-reference", "project-with-package-reference\project-with-package-reference.csproj", "{B2D919F2-171A-4D4A-9190-21ADC79BADA8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2D919F2-171A-4D4A-9190-21ADC79BADA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2D919F2-171A-4D4A-9190-21ADC79BADA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2D919F2-171A-4D4A-9190-21ADC79BADA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2D919F2-171A-4D4A-9190-21ADC79BADA8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {505F81A1-BA26-429D-9F77-3B04BBCB0E53}
+	EndGlobalSection
+EndGlobal

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -108,6 +108,10 @@
   <ItemGroup>
     <EmbeddedResource Include="resources\netcoreapp1.1-with-assembly-name.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\project-with-package-reference.csproj" />
+    <EmbeddedResource Include="resources\solution-with-package-reference.sln" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
As per Charlie Poole's suggestion vs-project-loader should not be aware of what unit testing framework is used. This decision is made by the nunit engine and the drivers it uses. As a consequence the method CheckProjectReferencesNunit() has been removed from class VSSolution.

I added a test including two new files as test resource and then applied this change. Trafis-CI is passing for the linux targets as well. MacOS has been queued but I do not expect any surprises.

Because of this change I had to adjust the implementation of test FromSolutionWithNonNunitTestProject() as we no longer let vs-project-loader decide whether or not a project contains tests. Instead this is left to the NUnit engine and the drivers it is using as per @CharliePoole 's suggestion.

Please review and comment if you require any further changes for this pull request to be acceptable.