### PR TITLE
Issue #14 - use default values instead of throwing

### DIFF
--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -348,14 +348,10 @@ namespace NUnit.Engine.Services.ProjectLoaders
             MsBuildDocument = _doc;
 
             XmlElement assemblyNameElement = (XmlElement)_doc.SelectSingleNode("/msbuild:Project/msbuild:PropertyGroup/msbuild:AssemblyName", namespaceManager);
-            if (assemblyNameElement == null)
-                throw new ApplicationException("Missing required element AssemblyName");
-            string assemblyName = assemblyNameElement.InnerText;
+            string assemblyName = assemblyNameElement == null ? Name : assemblyNameElement.InnerText;
 
             XmlElement outputTypeElement = (XmlElement)_doc.SelectSingleNode("/msbuild:Project/msbuild:PropertyGroup/msbuild:OutputType", namespaceManager);
-            if (outputTypeElement == null)
-                throw new ApplicationException("Missing required element OutputType");
-            string outputType = outputTypeElement.InnerText;
+            string outputType = outputTypeElement == null ? "Library" : outputTypeElement.InnerText;
 
             if (outputType == "Exe" || outputType == "WinExe")
                 assemblyName = assemblyName + ".exe";

--- a/src/tests/VSProjectTests.cs
+++ b/src/tests/VSProjectTests.cs
@@ -67,12 +67,19 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             Assert.Throws<FileNotFoundException>(() => new VSProject(@"/junk.csproj"));
         }
 
-        [TestCase("<VisualStudioProject><junk></VisualStudioProject>")]
-        [TestCase("<VisualStudioProject><junk></junk></VisualStudioProject>")]
-        public void InvalidXmlFormat(string invalidXml)
+        [Test]
+        public void InvalidXmlFormat()
         {
-            WriteInvalidFile(invalidXml);
+            WriteInvalidFile("<VisualStudioProject><junk></VisualStudioProject>");
             Assert.Throws<ArgumentException>(() => new VSProject(Path.Combine(Path.GetTempPath(), "invalid.csproj")));
+        }
+
+        [Test]
+        public void EmptyProject()
+        {
+            WriteInvalidFile("<VisualStudioProject><junk></junk></VisualStudioProject>");
+            VSProject project = new VSProject(Path.Combine(Path.GetTempPath(), "invalid.csproj"));
+            Assert.AreEqual(0, project.ConfigNames.Count);
         }
 
         [Test]
@@ -81,18 +88,6 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             WriteInvalidFile("<VisualStudioProject><CSharp><Build><Settings AssemblyName=\"invalid\" OutputType=\"Library\"></Settings></Build></CSharp></VisualStudioProject>");
             VSProject project = new VSProject(Path.Combine(Path.GetTempPath(), "invalid.csproj"));
             Assert.AreEqual(0, project.ConfigNames.Count);
-        }
-
-        [TestCase("csharp-missing-output-type.csproj", "OutputType")]
-        [TestCase("csharp-missing-assembly-name.csproj", "AssemblyName")]
-        public void MissingRequiredXmlElements(string projectName, string missingElementName)
-        {
-            using (TestResource file = new TestResource(projectName))
-            {
-                ArgumentException thrownException = Assert.Throws<ArgumentException>(() => new VSProject(file.Path));
-                Assert.IsNotNull(thrownException.InnerException);
-                Assert.That(thrownException.InnerException.Message, Does.Contain(missingElementName));
-            }
         }
     }
 }

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -163,9 +163,9 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
 
         [TestCase("netcoreapp1.1-minimal.csproj", "netcoreapp1.1-minimal")]
         [TestCase("netcoreapp1.1-with-assembly-name.csproj", "the-assembly-name")]
-        public void PicksUpCorrectAssemplyName(string resouresName, string expectedAssemblyName)
+        public void PicksUpCorrectAssemblyName(string resourceName, string expectedAssemblyName)
         {
-            using (TestResource file = new TestResource(resouresName))
+            using (TestResource file = new TestResource(resourceName))
             {
                 IProject project = _loader.LoadFrom(file.Path);
 

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -178,6 +178,23 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [TestCase("csharp-missing-assembly-name.csproj", "csharp-missing-assembly-name.exe")]
+        [TestCase("csharp-missing-output-type.csproj", "MissingOutputType.dll")]
+        public void PicksUpCorrectMsBuildProperty(string resourceName, string expectedOutputFilename)
+        {
+            using (TestResource file = new TestResource(resourceName))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+
+                foreach (var config in project.ConfigNames)
+                {
+                    TestPackage package = project.GetTestPackage(config);
+
+                    Assert.AreEqual(Path.GetFileName(package.SubPackages[0].FullName), expectedOutputFilename);
+                }
+            }
+        }
+
         [Test]
         public void FromVSSolution2003()
         {

--- a/src/tests/resources/csharp-missing-assembly-name.csproj
+++ b/src/tests/resources/csharp-missing-assembly-name.csproj
@@ -5,7 +5,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{6BF38215-C9D9-418D-9D81-4DECBA679223}</ProjectGuid>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MissingAssemblyName</RootNamespace>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>


### PR DESCRIPTION
Used MSBuild's defaults for AssemblyName & OutputType, but this resulted in a change in behavior: project files with valid XML but meaningless elements no longer throw an exception. I changed the unit tests to reflect that; now the extension just returns a package with no configurations.

This has the side effect of such a project returning the error message "File type is not supported" instead of throwing an exception when loaded by the console, but that behavior already occurs with projects that have complete MSBuild XML but no build configurations, so it seems to make sense.