### PR TITLE
fixes returned path when it contains $(Configuration) segment

### DIFF
--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
         /// VS Project extentions
         /// </summary>
         private static readonly string[] PROJECT_EXTENSIONS = { ".csproj", ".vbproj", ".vjsproj", ".vcproj", ".fsproj" };
-        
+
         /// <summary>
         /// VS Solution extension
         /// </summary>
@@ -67,9 +67,9 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
         #region Constructor
 
-        public VSProject( string projectPath )
+        public VSProject(string projectPath)
         {
-            ProjectPath = Path.GetFullPath( projectPath );
+            ProjectPath = Path.GetFullPath(projectPath);
 
             Load();
         }
@@ -121,7 +121,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
             string appbase = null;
             foreach (var name in _configs.Keys)
             {
-                if (configName == null)
+                if (configName == null || configName == name)
                 {
                     var config = _configs[name];
                     package.AddSubPackage(new TestPackage(config.AssemblyPath));
@@ -129,16 +129,6 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
                     break;
                 }
-
-                if (configName == name)
-                {
-                    var config = _configs[name];
-                    package.AddSubPackage(new TestPackage(config.AssemblyPath.Replace("$(Configuration)", configName)));
-                    appbase = config.OutputDirectory.Replace("$(Configuration)", configName);
-
-                    break;
-                }
-
             }
 
             if (appbase != null)
@@ -156,33 +146,33 @@ namespace NUnit.Engine.Services.ProjectLoaders
         /// </summary>
         public string Name
         {
-            get { return Path.GetFileNameWithoutExtension( ProjectPath ); }
+            get { return Path.GetFileNameWithoutExtension(ProjectPath); }
         }
 
         #endregion
 
         #region Public Methods
 
-        public static bool IsProjectFile( string path )
+        public static bool IsProjectFile(string path)
         {
             if (path.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
                 return false;
 
-            if ( path.ToLower().IndexOf( "http:" ) >= 0 )
+            if (path.ToLower().IndexOf("http:") >= 0)
                 return false;
-        
-            string extension = Path.GetExtension( path );
 
-            foreach( string validExtension in PROJECT_EXTENSIONS )
-                if ( extension == validExtension )
+            string extension = Path.GetExtension(path);
+
+            foreach (string validExtension in PROJECT_EXTENSIONS)
+                if (extension == validExtension)
                     return true;
 
             return false;
         }
 
-        public static bool IsSolutionFile( string path )
+        public static bool IsSolutionFile(string path)
         {
-            return Path.GetExtension( path ) == SOLUTION_EXTENSION;
+            return Path.GetExtension(path) == SOLUTION_EXTENSION;
         }
 
         #endregion
@@ -194,8 +184,8 @@ namespace NUnit.Engine.Services.ProjectLoaders
         /// </summary>
         private void Load()
         {
-            if ( !IsProjectFile( ProjectPath ) ) 
-                ThrowInvalidFileType( ProjectPath );
+            if (!IsProjectFile(ProjectPath))
+                ThrowInvalidFileType(ProjectPath);
 
             StreamReader rdr = new StreamReader(ProjectPath, System.Text.Encoding.UTF8);
 
@@ -250,10 +240,11 @@ namespace NUnit.Engine.Services.ProjectLoaders
         /// is only called for file extensions .csproj.
         /// </summary>
         /// <returns>True if the project was successfully loaded, false otherwise.</returns>
-        private bool TryLoadDotNetCoreProject() {
+        private bool TryLoadDotNetCoreProject()
+        {
             XmlNode root = _doc.SelectSingleNode("Project");
 
-            if (root != null && SafeAttributeValue(root, "Sdk") != null) 
+            if (root != null && SafeAttributeValue(root, "Sdk") != null)
             {
                 string targetFramework = _doc.SelectSingleNode("Project/PropertyGroup/TargetFramework").InnerText;
 
@@ -382,7 +373,8 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
                 if (name == null)
                 {
-                    commonOutputPath = outputPath;
+                    if (outputPathElement != null)
+                        commonOutputPath = outputPath;
                     continue;
                 }
 
@@ -390,7 +382,8 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     outputPath = commonOutputPath;
 
                 if (outputPath != null)
-                    _configs.Add(name, new ProjectConfig(this, name, outputPath, assemblyName));
+                    _configs.Add(name, new ProjectConfig(this, name, outputPath.Replace("$(Configuration)", name), assemblyName));
+
             }
         }
 
@@ -508,7 +501,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
 
             public string OutputDirectory
             {
-                get { return Normalize(Path.Combine(Path.GetDirectoryName(_project.ProjectPath), _outputPath));  }
+                get { return Normalize(Path.Combine(Path.GetDirectoryName(_project.ProjectPath), _outputPath)); }
             }
 
             public string AssemblyPath

--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -121,13 +121,24 @@ namespace NUnit.Engine.Services.ProjectLoaders
             string appbase = null;
             foreach (var name in _configs.Keys)
             {
-                if (configName == null || configName == name)
+                if (configName == null)
                 {
                     var config = _configs[name];
                     package.AddSubPackage(new TestPackage(config.AssemblyPath));
                     appbase = config.OutputDirectory;
+
                     break;
                 }
+
+                if (configName == name)
+                {
+                    var config = _configs[name];
+                    package.AddSubPackage(new TestPackage(config.AssemblyPath.Replace("$(Configuration)", configName)));
+                    appbase = config.OutputDirectory.Replace("$(Configuration)", configName);
+
+                    break;
+                }
+
             }
 
             if (appbase != null)

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -312,17 +312,17 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 Assert.That(debugPackage.SubPackages[0].FullName, Does.Not.Contain(@"$(Configuration)"),
                     "Assembly path contains '$(Configuration)' which should be replaced with config name.");
 
-                Assert.That(debugPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Debug\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll"),
+                Assert.That(debugPackage.SubPackages[0].FullName, Does.EndWith(NormalizePath(@"\csharp-sample\.bin\Debug\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll")),
                     "Invalid Debug assembly path");
 
                 var releasePackage = project.GetTestPackage("Release");
                 Assert.AreEqual(1, releasePackage.SubPackages.Count, "Release should have 1 assemblies");
-                Assert.That(releasePackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Release\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll"),
+                Assert.That(releasePackage.SubPackages[0].FullName, Does.EndWith(NormalizePath(@"\csharp-sample\.bin\Release\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll")),
                     "Invalid Release assembly path");
 
                 var fixedPathPackage = project.GetTestPackage("FixedPath");
                 Assert.AreEqual(1, fixedPathPackage.SubPackages.Count, "FixedPath should have 1 assemblies");
-                Assert.That(fixedPathPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\FixedPath\TestTemplatedPathsAssembly.dll"),
+                Assert.That(fixedPathPackage.SubPackages[0].FullName, Does.EndWith(NormalizePath(@"\csharp-sample\FixedPath\TestTemplatedPathsAssembly.dll")),
                     "Invalid FixedPath assembly path");
             }
         }

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -299,9 +299,9 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
         }
 
         [Test]
-        public void FromProjectWithParametrizedPaths()
+        public void FromProjectWithTemplatedPaths()
         {
-            using (var file = new TestResource("TestDynamicPaths.csproj", NormalizePath(@"csharp-sample\csharp-sample.csproj")))
+            using (var file = new TestResource("TestTemplatedPaths.csproj", NormalizePath(@"csharp-sample\csharp-sample.csproj")))
             {
                 IProject project = _loader.LoadFrom(file.Path);
                 Assert.AreEqual(3, project.ConfigNames.Count);
@@ -309,20 +309,20 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
                 var debugPackage = project.GetTestPackage("Debug");
                 Assert.AreEqual(1, debugPackage.SubPackages.Count, "Debug should have 1 assembly");
 
-                Assert.That(!debugPackage.SubPackages[0].FullName.Contains(@"$(Configuration)"),
+                Assert.That(debugPackage.SubPackages[0].FullName, Does.Not.Contain(@"$(Configuration)"),
                     "Assembly path contains '$(Configuration)' which should be replaced with config name.");
 
-                Assert.That(debugPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Debug\TestDynamicPathsAssembly\TestDynamicPathsAssembly.dll"),
+                Assert.That(debugPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Debug\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll"),
                     "Invalid Debug assembly path");
 
                 var releasePackage = project.GetTestPackage("Release");
                 Assert.AreEqual(1, releasePackage.SubPackages.Count, "Release should have 1 assemblies");
-                Assert.That(releasePackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Release\TestDynamicPathsAssembly\TestDynamicPathsAssembly.dll"),
+                Assert.That(releasePackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Release\TestTemplatedPathsAssembly\TestTemplatedPathsAssembly.dll"),
                     "Invalid Release assembly path");
 
                 var fixedPathPackage = project.GetTestPackage("FixedPath");
                 Assert.AreEqual(1, fixedPathPackage.SubPackages.Count, "FixedPath should have 1 assemblies");
-                Assert.That(fixedPathPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\FixedPath\TestDynamicPathsAssembly.dll"),
+                Assert.That(fixedPathPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\FixedPath\TestTemplatedPathsAssembly.dll"),
                     "Invalid FixedPath assembly path");
             }
         }

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -298,6 +298,35 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [Test]
+        public void FromProjectWithParametrizedPaths()
+        {
+            using (var file = new TestResource("TestDynamicPaths.csproj", NormalizePath(@"csharp-sample\csharp-sample.csproj")))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+                Assert.AreEqual(3, project.ConfigNames.Count);
+
+                var debugPackage = project.GetTestPackage("Debug");
+                Assert.AreEqual(1, debugPackage.SubPackages.Count, "Debug should have 1 assembly");
+
+                Assert.That(!debugPackage.SubPackages[0].FullName.Contains(@"$(Configuration)"),
+                    "Assembly path contains '$(Configuration)' which should be replaced with config name.");
+
+                Assert.That(debugPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Debug\TestDynamicPathsAssembly\TestDynamicPathsAssembly.dll"),
+                    "Invalid Debug assembly path");
+
+                var releasePackage = project.GetTestPackage("Release");
+                Assert.AreEqual(1, releasePackage.SubPackages.Count, "Release should have 1 assemblies");
+                Assert.That(releasePackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\.bin\Release\TestDynamicPathsAssembly\TestDynamicPathsAssembly.dll"),
+                    "Invalid Release assembly path");
+
+                var fixedPathPackage = project.GetTestPackage("FixedPath");
+                Assert.AreEqual(1, fixedPathPackage.SubPackages.Count, "FixedPath should have 1 assemblies");
+                Assert.That(fixedPathPackage.SubPackages[0].FullName.EndsWith(@"\csharp-sample\FixedPath\TestDynamicPathsAssembly.dll"),
+                    "Invalid FixedPath assembly path");
+            }
+        }
+
         private string NormalizePath(string path)
         {
             return this.PathSeparatorLookup.Replace(path, Path.DirectorySeparatorChar.ToString());

--- a/src/tests/resources/TestDynamicPaths.csproj
+++ b/src/tests/resources/TestDynamicPaths.csproj
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{0062E340-058B-4ADC-B163-32CD6DE9F8F4}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <RootNamespace>TestDynamicPaths</RootNamespace>
+    <AssemblyName>TestDynamicPathsAssembly</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <BaseIntermediateOutputPath>.obj\TestDynamicPathsAssembly</BaseIntermediateOutputPath>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <NoStdLib>False</NoStdLib>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <SignAssembly>False</SignAssembly>
+    <DelaySign>False</DelaySign>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <NoWin32Manifest>False</NoWin32Manifest>
+    <IntermediateOutputPath>.obj\TestDynamicPathsAssembly\$(Configuration)\</IntermediateOutputPath>
+    <TargetFrameworkProfile />
+    <OutputPath>.bin\$(Configuration)\TestDynamicPathsAssembly\</OutputPath>
+    <RunCodeAnalysis>False</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <BaseAddress>4194304</BaseAddress>
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+    <FileAlignment>4096</FileAlignment>
+    <Prefer32Bit>False</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
+    <BaseAddress>4194304</BaseAddress>
+    <PlatformTarget>x86</PlatformTarget>
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+    <FileAlignment>4096</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    <DefineConstants>TRACE</DefineConstants>
+    <StartAction>Project</StartAction>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'FixedPath' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>FixedPath\</OutputPath>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="StructureMap, Version=4.5.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StructureMap.4.5.3\lib\net45\StructureMap.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Linq" />
+    <Reference Include="System.Linq.Expressions" />
+    <Reference Include="System.Linq.Queryable" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Domain\TestDynamicPathsAssembly.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/src/tests/resources/TestTemplatedPaths.csproj
+++ b/src/tests/resources/TestTemplatedPaths.csproj
@@ -5,11 +5,11 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
-    <RootNamespace>TestDynamicPaths</RootNamespace>
-    <AssemblyName>TestDynamicPathsAssembly</AssemblyName>
+    <RootNamespace>TestTemplatedPaths</RootNamespace>
+    <AssemblyName>TestTemplatedPathsAssembly</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <BaseIntermediateOutputPath>.obj\TestDynamicPathsAssembly</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>.obj\TestTemplatedPathsAssembly</BaseIntermediateOutputPath>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
     <WarningLevel>4</WarningLevel>
@@ -18,9 +18,9 @@
     <DelaySign>False</DelaySign>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <NoWin32Manifest>False</NoWin32Manifest>
-    <IntermediateOutputPath>.obj\TestDynamicPathsAssembly\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath>.obj\TestTemplatedPathsAssembly\$(Configuration)\</IntermediateOutputPath>
     <TargetFrameworkProfile />
-    <OutputPath>.bin\$(Configuration)\TestDynamicPathsAssembly\</OutputPath>
+    <OutputPath>.bin\$(Configuration)\TestTemplatedPathsAssembly\</OutputPath>
     <RunCodeAnalysis>False</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
@@ -93,7 +93,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Domain\TestDynamicPathsAssembly.cs" />
+    <Compile Include="Domain\TestTemplatedPathsAssembly.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -112,6 +112,9 @@
     <EmbeddedResource Include="resources\project-with-package-reference.csproj" />
     <EmbeddedResource Include="resources\solution-with-package-reference.sln" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\TestDynamicPaths.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -113,7 +113,7 @@
     <EmbeddedResource Include="resources\solution-with-package-reference.sln" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="resources\TestDynamicPaths.csproj" />
+    <EmbeddedResource Include="resources\TestTemplatedPaths.csproj" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Hi, I've noticed that projects with compilation paths containing dynamic part **_$(Configuration)_** aren't well resolved - dynamic segment isn't replaced with configuration name.
In my solution it is replaced by value from current PropertyGroup section.