### PR TITLE
Fixes problem with projects containing duplicated sections

### DIFF
--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -382,7 +382,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     outputPath = commonOutputPath;
 
                 if (outputPath != null)
-                    _configs.Add(name, new ProjectConfig(this, name, outputPath.Replace("$(Configuration)", name), assemblyName));
+                    _configs[name] = new ProjectConfig(this, name, outputPath.Replace("$(Configuration)", name), assemblyName);
 
             }
         }

--- a/src/extension/VSProject.cs
+++ b/src/extension/VSProject.cs
@@ -361,6 +361,7 @@ namespace NUnit.Engine.Services.ProjectLoaders
                 assemblyName = assemblyName + ".dll";
 
             string commonOutputPath = null;
+            var explicitOutputPaths = new Dictionary<string, string>();
 
             foreach (XmlElement configNode in nodes)
             {
@@ -378,8 +379,11 @@ namespace NUnit.Engine.Services.ProjectLoaders
                     continue;
                 }
 
+                if (outputPathElement != null)
+                    explicitOutputPaths[name] = outputPath;
+
                 if (outputPath == null)
-                    outputPath = commonOutputPath;
+                    outputPath = explicitOutputPaths.ContainsKey(name) ? explicitOutputPaths[name] : commonOutputPath;
 
                 if (outputPath != null)
                     _configs[name] = new ProjectConfig(this, name, outputPath.Replace("$(Configuration)", name), assemblyName);

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -333,13 +333,19 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             using (var file = new TestResource("test-duplicated-key-project.csproj", NormalizePath(@"csharp-sample\csharp-sample.csproj")))
             {
                 IProject project = _loader.LoadFrom(file.Path);
-                Assert.AreEqual(2, project.ConfigNames.Count);
+                Assert.AreEqual(3, project.ConfigNames.Count);
 
                 var debugPackage = project.GetTestPackage("Debug");
                 Assert.AreEqual(1, debugPackage.SubPackages.Count, "Debug should have 1 assembly");
 
                 var releasePackage = project.GetTestPackage("Release");
                 Assert.AreEqual(1, releasePackage.SubPackages.Count, "Release should have 1 assembly");
+
+                var secondDebugPackage = project.GetTestPackage("Debug2ndTest");
+                Assert.AreEqual(1, secondDebugPackage.SubPackages.Count, "Debug2ndTest should have 1 assembly");
+                Assert.AreEqual(1, secondDebugPackage.SubPackages.Count, "Debug2ndTest should have 1 assemblies");
+                Assert.That(secondDebugPackage.SubPackages[0].FullName, Does.EndWith(NormalizePath(@"\csharp-sample\Debug2ndTest\SecondTest\Test.exe")),
+                    "Invalid Debug2ndTest assembly path");
             }
         }
 

--- a/src/tests/VisualStudioProjectLoaderTests.cs
+++ b/src/tests/VisualStudioProjectLoaderTests.cs
@@ -327,6 +327,22 @@ namespace NUnit.Engine.Services.ProjectLoaders.Tests
             }
         }
 
+        [Test]
+        public void ProjectWithDuplicatedSections()
+        {
+            using (var file = new TestResource("test-duplicated-key-project.csproj", NormalizePath(@"csharp-sample\csharp-sample.csproj")))
+            {
+                IProject project = _loader.LoadFrom(file.Path);
+                Assert.AreEqual(2, project.ConfigNames.Count);
+
+                var debugPackage = project.GetTestPackage("Debug");
+                Assert.AreEqual(1, debugPackage.SubPackages.Count, "Debug should have 1 assembly");
+
+                var releasePackage = project.GetTestPackage("Release");
+                Assert.AreEqual(1, releasePackage.SubPackages.Count, "Release should have 1 assembly");
+            }
+        }
+
         private string NormalizePath(string path)
         {
             return this.PathSeparatorLookup.Replace(path, Path.DirectorySeparatorChar.ToString());

--- a/src/tests/resources/test-duplicated-key-project.csproj
+++ b/src/tests/resources/test-duplicated-key-project.csproj
@@ -71,4 +71,13 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release' ">
     <DefineConstants>TRACE;RELEASE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug2ndTest' ">
+    <OutputPath>$(Configuration)\SecondTest\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug2ndTest' ">
+    <Optimize>False</Optimize>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
 </Project>

--- a/src/tests/resources/test-duplicated-key-project.csproj
+++ b/src/tests/resources/test-duplicated-key-project.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Test</RootNamespace>
+    <AssemblyName>Test</AssemblyName>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A518F172-99B1-4A83-8A40-D9EFBA0E4270}</ProjectGuid>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <StartAction>Project</StartAction>
+    <NoWin32Manifest>False</NoWin32Manifest>
+    <BaseIntermediateOutputPath>.obj\Test</BaseIntermediateOutputPath>
+    <IntermediateOutputPath>.obj\Test\$(Configuration) - $(Platform)\</IntermediateOutputPath>
+    <OutputPath>.bin\$(Configuration)\Test\</OutputPath>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <Optimize>False</Optimize>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>Full</DebugType>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <Optimize>True</Optimize>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+    <BaseAddress>4194304</BaseAddress>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <FileAlignment>4096</FileAlignment>
+    <Prefer32Bit>False</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PostBuildEvent>rem some post-build actions</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PostBuildEvent>rem some post-build actions</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'x86' ">
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+    <BaseAddress>4194304</BaseAddress>
+    <PlatformTarget>x86</PlatformTarget>
+    <FileAlignment>4096</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug' ">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release' ">
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/tests/vs-project-loader.tests.csproj
+++ b/src/tests/vs-project-loader.tests.csproj
@@ -115,6 +115,9 @@
   <ItemGroup>
     <EmbeddedResource Include="resources\TestTemplatedPaths.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="resources\test-duplicated-key-project.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Hi, I've got case, when a project file contains duplicated sections `PropertyGroup` with the same `Condition`.
That makes duplicated key exception.
I'm sending You unit test and my solution to the problem.